### PR TITLE
Add gem configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ And then execute:
 $ bundle install
 ```
 
+## Configure
+
+Impact Travel Engine provides you an easier way to configure it's underlying
+dependencies. Once you have the required credentials then you can add an
+initializer to set up your configuration.
+
+```ruby
+ImpactTravel.configure do |config|
+  config.api_key = "DISOUNT_NETWORK_API_KEY"
+end
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/config/initializers/discountnetwork.rb
+++ b/config/initializers/discountnetwork.rb
@@ -1,3 +1,0 @@
-DiscountNetwork.configure do |config|
-  config.api_key = "MY_API_KEY"
-end

--- a/lib/impact_travel.rb
+++ b/lib/impact_travel.rb
@@ -1,4 +1,5 @@
 require "impact_travel/engine"
+require "impact_travel/configuration"
 
 module ImpactTravel
 end

--- a/lib/impact_travel/configuration.rb
+++ b/lib/impact_travel/configuration.rb
@@ -1,0 +1,17 @@
+module ImpactTravel
+  class Configuration
+    attr_accessor :api_key
+  end
+
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configuration=(config)
+    @configuration = config
+  end
+end

--- a/lib/impact_travel/engine.rb
+++ b/lib/impact_travel/engine.rb
@@ -1,5 +1,11 @@
 module ImpactTravel
   class Engine < ::Rails::Engine
     isolate_namespace ImpactTravel
+
+    config.after_initialize do
+      DiscountNetwork.configure do |dn_config|
+        dn_config.api_key = ImpactTravel.configuration.api_key
+      end
+    end
   end
 end

--- a/spec/dummy/config/initializers/impact_travel.rb
+++ b/spec/dummy/config/initializers/impact_travel.rb
@@ -1,0 +1,3 @@
+ImpactTravel.configure do |config|
+  config.api_key = "SECRET_API_KEY"
+end

--- a/spec/impact_travel/configuration_spec.rb
+++ b/spec/impact_travel/configuration_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe ImpactTravel::Configuration do
+  after { restore_configuration_to_default }
+
+  describe ".configuration" do
+    it "returns the configuration object" do
+      api_key = "discountnetwork_secret_key"
+      ImpactTravel.configure { |config| config.api_key = api_key }
+
+      expect(ImpactTravel.configuration.api_key).to eq(api_key)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,8 @@ RSpec.configure do |config|
   config.order = :random
   config.use_transactional_fixtures = true
 end
+
+def restore_configuration_to_default
+  ImpactTravel.configuration = nil
+  ImpactTravel.configure {}
+end


### PR DESCRIPTION
This engine depends on underlying discoutnetwork gem, which requires to set up discount network API keys. So let's add an easier way for client application to set their discount network API keys. Usages:

```ruby
ImpactTravel.configure do |config|
  config.api_key = "DN_API_KEY"
end
```